### PR TITLE
More spotify fixes

### DIFF
--- a/database/scripts/spotify
+++ b/database/scripts/spotify
@@ -6,9 +6,10 @@ unzip resources_old.zip -d resources_old/
 
 
 if [[ $1 == *.svg ]]; then
-    inkscape $1 --export-png=resources_old/_linux/spotify_icon.ico
+    inkscape $1 --export-png=resources_old/_linux/$2
+else
+    convert $1 --background none resources_old/_linux/$2
 fi
-    convert $1 --background none resources_old/_linux/spotify_icon.ico
     
 cd resources_old/
 zip -r resources_patched.zip .

--- a/script.py
+++ b/script.py
@@ -145,7 +145,7 @@ def copy_files():
                         else:
                             sys.exit('hardcoded file has to be svg or png. Other formats are not supported yet')
                     else:
-                        subprocess.call([script_name, filename], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                        subprocess.call([script_name, filename, symlink_icon], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                         print("%s -- fixed using %s"%(app, filename))
     else:
         sys.exit("The application we support is not installed. Please report this if this is not the case")


### PR DESCRIPTION
Ok that was easy. It still happens that the wrong icon is taken, this can only be circumenvented by using a different name for the panel icon (`spotify-client-panel.svg` for example) Since @Foggalong wants to do this anyway, I think it's possible to create a PR at Numix with the corresponding symlinks. If that happens we can change `spotify.txt` accordingly. 