### PR TITLE
Fixes small errors in chrome script + a few other suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,25 @@ Fixes Hardcoded tray icons in Linux
   ```bash
     sudo apt-get install python3-cairosvg
   ```
-  
-  2. Install inkscape, if you don't use Spotify ignore this step (used to convert .svg icons to .ico)
-  ```bash
-  sudo apt-get install inkscape
-  ```
-  3. Install the patched version of ```sni-qt``` if you use any QT applications
+
+  2. Install the patched version of ```sni-qt``` if you use any QT applications
   ```bash
   sudo add-apt-repository ppa:cybre/sni-qt-eplus
   sudo apt-get update && sudo apt-get dist-upgrade
   sudo apt-get install sni-qt
 
-  ```  
-  4. Install ```nodejs``` if you use Google Chrome
+  ```
+  3. Install ```nodejs``` if you use Google Chrome
   ```bash
   sudo apt-get install nodejs
   ``` 
 
-  5. Open the script.py using this command (root privileges needed because hardcoded icons are usually in `/opt` or `/usr`)
+  4. Open the script.py using this command (root privileges needed because hardcoded icons are usually in `/opt` or `/usr`)
   ```bash
     sudo python3 script.py
   ```
   
-  6. Enjoy!
+  5. Enjoy!
 
 ### Supported applications
 We now support:

--- a/database/google-chrome
+++ b/database/google-chrome
@@ -1,4 +1,4 @@
-7360.png, google-chrome-indicator.svg, chrome
-7361.png, google-chrome-indicator-disabled.svg, chrome
+7360.png, google-chrome-notification.svg, chrome
+7361.png, google-chrome-notification-disabled.svg, chrome
 7358.png, google-chrome-no-notification.svg, chrome
 7359.png, google-chrome-no-notification-disabled.svg, chrome

--- a/database/owncloud
+++ b/database/owncloud
@@ -1,6 +1,6 @@
 6a85c1b1eca5f176490afbea40b5a85b.png, state-error.svg, qt-tray
 e9b111ea19684326fa5140f7d14b215b.png, state-information.svg, qt-tray
-9d626aa048ccbd28c9a5bf6bbaadee43.png, state-offline-svg, qt-tray
+9d626aa048ccbd28c9a5bf6bbaadee43.png, state-offline.svg, qt-tray
 a4d0f4e492fad2e38e62dc68de83aaa0.png, state-ok.svg, qt-tray
 4c8bee6fca0c59f47088f37c25880a24.png, state-pause.svg, qt-tray
 23064844cb89c0654026212a3faa910f.png, state-sync.svg, qt-tray

--- a/database/scripts/chrome
+++ b/database/scripts/chrome
@@ -6,7 +6,7 @@ node ./node-chrome-pak.js unpack chrome_100_percent_old.pak
 if [[ $1 == *.svg ]]; then
     inkscape $1 --export-png=extracted/$2
 else
-    convert $1 --background none extracted/$2
+    cp $1 extracted/$2
 fi
 
 node ./node-chrome-pak.js pack ./extracted ./chrome_100_percent_old.pak

--- a/database/scripts/chrome
+++ b/database/scripts/chrome
@@ -4,7 +4,7 @@ cp $3/chrome_100_percent.pak chrome_100_percent_old.pak
 node ./node-chrome-pak.js unpack chrome_100_percent_old.pak
 
 if [[ $1 == *.svg ]]; then
-    python3 svg2png.py $1 $2
+    python3 svg2png.py $1 extracted/$2
 else
     cp $1 extracted/$2
 fi

--- a/database/scripts/chrome
+++ b/database/scripts/chrome
@@ -4,7 +4,7 @@ cp $3/chrome_100_percent.pak chrome_100_percent_old.pak
 node ./node-chrome-pak.js unpack chrome_100_percent_old.pak
 
 if [[ $1 == *.svg ]]; then
-    inkscape $1 --export-png=extracted/$2
+    python3 svg2png.py $1 $2
 else
     cp $1 extracted/$2
 fi

--- a/database/scripts/spotify
+++ b/database/scripts/spotify
@@ -6,7 +6,7 @@ unzip resources_old.zip -d resources_old/
 
 
 if [[ $1 == *.svg ]]; then
-    inkscape $1 --export-png=resources_old/_linux/$2
+    python3 svg2png.py $1 resources_old/_linux/$2
 else
     convert $1 --background none resources_old/_linux/$2
 fi

--- a/database/scripts/svg2png.py
+++ b/database/scripts/svg2png.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python3
+
+from cairosvg import svg2png
+import sys
+
+origfile = sys.argv[1]
+symlfile = sys.argv[2]
+
+with open(origfile, 'r') as content_file:
+    svg = content_file.read()
+    fout = open(symlfile, 'wb')
+    svg2png(bytestring=bytes(svg, 'UTF-8'), write_to=fout)
+    fout.close()

--- a/script.py
+++ b/script.py
@@ -146,9 +146,9 @@ def copy_files():
                     extension_theme = path.splitext(filename)[1]
                     if not script:
                         if symlink_icon:
-                            output = "/" + apps[app]['link'] + "/" + symlink_icon
+                            output = apps[app]['link'] + "/" + symlink_icon
                         else:
-                            output = "/" + apps[app]['link'] + "/" + icon  # Output icon
+                            output = apps[app]['link'] + "/" + icon  # Output icon
                         if extension_theme == extension_orig:
                             Popen(['ln', '-sf', filename, output])
                             print("%s -- fixed using %s" % (app, filename))
@@ -164,6 +164,8 @@ def copy_files():
                         else:
                             call([script_name, filename, symlink_icon, folder], stdout=PIPE, stderr=PIPE)
                         print("%s -- fixed using %s" % (app, filename))
+                else:
+                    print("Theme icon for %s not found. You should report that to the theme maintainer!" %(base_icon))
     else:
         exit("No apps to fix! Please report on GitHub if this is not the case")
 

--- a/script.py
+++ b/script.py
@@ -144,6 +144,8 @@ def copy_files():
                 if theme_icon:
                     filename = theme_icon.get_filename()
                     extension_theme = path.splitext(filename)[1]
+                    if extension_theme not in ('.png', '.svg'): #catching the unrealistic case that theme is neither svg nor png
+                        exit('theme icons need to be svg or png files other formats not supported yet')
                     if not script:
                         if symlink_icon:
                             output = apps[app]['link'] + "/" + symlink_icon

--- a/script.py
+++ b/script.py
@@ -145,7 +145,7 @@ def copy_files():
                     filename = theme_icon.get_filename()
                     extension_theme = path.splitext(filename)[1]
                     if extension_theme not in ('.png', '.svg'): #catching the unrealistic case that theme is neither svg nor png
-                        exit('theme icons need to be svg or png files other formats not supported yet')
+                        exit('Theme icons need to be svg or png files other formats are not supported')
                     if not script:
                         if symlink_icon:
                             output = apps[app]['link'] + "/" + symlink_icon
@@ -158,7 +158,7 @@ def copy_files():
                             convert2svg(filename,output)
                             print("%s -- fixed using %s" % (app, filename))
                         else:
-                            exit('hardcoded file has to be svg or png. Other formats are not supported yet')
+                            exit('Hardcoded file has to be svg or png. Other formats are not supported yet')
                     else:
                         folder = apps[app]['link']
                         if script_name == qt_script:
@@ -167,7 +167,7 @@ def copy_files():
                             call([script_name, filename, symlink_icon, folder], stdout=PIPE, stderr=PIPE)
                         print("%s -- fixed using %s" % (app, filename))
                 else:
-                    print("Theme icon for %s not found. You should report that to the theme maintainer!" %(base_icon))
+                    print("%s -- theme icon not found. You should report that to the theme maintainer!" %(base_icon))
     else:
         exit("No apps to fix! Please report on GitHub if this is not the case")
 


### PR DESCRIPTION
The script was not executable, and since the destination file is meant to be a `png` file it is sufficient to just copy it, if the source file is a png as well. But cool work!