### PR TITLE
update spotify script

### DIFF
--- a/database/scripts/spotify
+++ b/database/scripts/spotify
@@ -8,7 +8,7 @@ unzip resources_old.zip -d resources_old/
 if [[ $1 == *.svg ]]; then
     python3 svg2png.py $1 resources_old/_linux/$2
 else
-    convert $1 --background none resources_old/_linux/$2
+    cp resources_old/_linux/$2
 fi
 
 cd resources_old/

--- a/database/scripts/spotify
+++ b/database/scripts/spotify
@@ -8,7 +8,7 @@ unzip resources_old.zip -d resources_old/
 if [[ $1 == *.svg ]]; then
     python3 svg2png.py $1 resources_old/_linux/$2
 else
-    cp resources_old/_linux/$2
+    cp $1 resources_old/_linux/$2
 fi
 
 cd resources_old/


### PR DESCRIPTION
A convert in spotify script is not really necessary, a cp is sufficient if source is png and destination is ico (it seems that the `ico` file in `resources.zip` is in fact just a funny named `png` file), therefore `cp is sufficient.