### PR TITLE
Creates sni_qt_folder if it doesn't exist

### DIFF
--- a/script.py
+++ b/script.py
@@ -2,7 +2,7 @@
 
 from csv import reader
 from gi.repository import Gtk
-from os import environ, geteuid, getlogin, listdir, path
+from os import environ, geteuid, getlogin, listdir, path, makedirs
 from subprocess import Popen, PIPE, call
 from sys import exit
 
@@ -162,6 +162,8 @@ def copy_files():
                     else:
                         folder = apps[app]['link']
                         if script_name == qt_script:
+                            if not path.exists(directory):
+                                os.makedirs(sni_qt_folder)
                             call([script_name, filename, symlink_icon, sni_qt_folder], stdout=PIPE, stderr=PIPE)
                         else:
                             call([script_name, filename, symlink_icon, folder], stdout=PIPE, stderr=PIPE)

--- a/script.py
+++ b/script.py
@@ -162,7 +162,7 @@ def copy_files():
                     else:
                         folder = apps[app]['link']
                         if script_name == qt_script:
-                            if not path.exists(directory):
+                            if not path.exists(sni_qt_folder):
                                 makedirs(sni_qt_folder)
                             call([script_name, filename, symlink_icon, sni_qt_folder], stdout=PIPE, stderr=PIPE)
                         else:

--- a/script.py
+++ b/script.py
@@ -163,7 +163,7 @@ def copy_files():
                         folder = apps[app]['link']
                         if script_name == qt_script:
                             if not path.exists(directory):
-                                os.makedirs(sni_qt_folder)
+                                makedirs(sni_qt_folder)
                             call([script_name, filename, symlink_icon, sni_qt_folder], stdout=PIPE, stderr=PIPE)
                         else:
                             call([script_name, filename, symlink_icon, folder], stdout=PIPE, stderr=PIPE)


### PR DESCRIPTION
Title says it. It seems that this folder is not created automatically after the new sni-qt-version is installed