### PR TITLE
Fixes symlinks for skype (and other qt apps)

### DIFF
--- a/database/scripts/qt-tray
+++ b/database/scripts/qt-tray
@@ -19,4 +19,4 @@ if len(sys.argv) <= 4:
 	else:
 	    symlink(origfile, symlfile)
 else:
-	symlink(origfile, sys.argv[3] + "/" + sys.argv[4])
+	symlink(sys.argv[3] + "/" + sys.argv[4], symlfile)


### PR DESCRIPTION
The order was incorrect. Apart from that it works :+1: