### PR TITLE
Catches error when symlink tried to symlink to existing file

### DIFF
--- a/database/scripts/qt-tray
+++ b/database/scripts/qt-tray
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 import sys
-from os import symlink, chown, getenv
+from os import symlink, chown, getenv, remove
 from cairosvg import svg2png
 
 origfile = sys.argv[1]
@@ -15,4 +15,8 @@ if origfile.endswith(".svg"):
     fout.close()
     chown(symlfile, int(getenv('SUDO_UID')), int(getenv('SUDO_GID'))) 
 else:
-    symlink(origfile, symlfile)
+    try:
+        remove(symlfile)
+        symlink(origfile, symlfile)
+    except FileNotFoundError:
+        symlink(origfile, symlfile)

--- a/script.py
+++ b/script.py
@@ -9,7 +9,7 @@ Licence : GPL
 
 from csv import reader
 from gi.repository import Gtk
-from os import environ, geteuid, getlogin, listdir, path, makedirs, chown, getenv, symlink
+from os import environ, geteuid, getlogin, listdir, path, makedirs, chown, getenv, symlink, remove
 from subprocess import Popen, PIPE, call
 from platform import linux_distribution
 from sys import exit
@@ -251,7 +251,11 @@ def install():
                                 chown(app_sni_qt_path, int(getenv('SUDO_UID')), int(getenv('SUDO_GID')))
                             #If the sni-qt icon can be symlinked to an other one
                             if len(icon) == 4:
-                                symlink(app_sni_qt_path+"/"+icon[3], app_sni_qt_path+"/"+symlink_icon)
+                                try:
+                                    remove(app_sni_qt_path+"/"+symlink_icon)
+                                    symlink(app_sni_qt_path+"/"+icon[3], app_sni_qt_path+"/"+symlink_icon)
+                                except FileNotFoundError:
+                                    symlink(app_sni_qt_path+"/"+icon[3], app_sni_qt_path+"/"+symlink_icon)
                             else:
                                 p = Popen([script_name, filename, symlink_icon, app_sni_qt_path], stdout=PIPE, stderr=PIPE)
                                 output, err = p.communicate()


### PR DESCRIPTION
The symlink function raises an error when the file does already exist. Therefore removing it beforehand is necessary