### PR TITLE
New dependency - fixes #104

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ For a better experience use [Numix icon theme](https://github.com/numixproject/n
   git clone https://github.com/bil-elmoussaoui/Hardcode-Tray.git
   ```
 
-  2. Install `python3-cairosvg`
+  2. Install `python3-cairocffi` & `python3-cairosvg`
   ```bash
-  sudo apt-get install python3-cairosvg
+  sudo apt-get install python3-cairocffi python3-cairosvg
   ```
 
   3. Install the patched version of `sni-qt` if you use any Qt applications


### PR DESCRIPTION
I found the solution for #104! As of v1.0.16-1 it would seem that the svg2png function also depends on `cairocffi` which isn't install ed automatically as part of `cairosvg`