### PR TITLE
fix attributeerror if user is not running a de

### DIFF
--- a/script.py
+++ b/script.py
@@ -110,8 +110,14 @@ def detect_de():
     """
         Detects the desktop environment, used to choose the proper icons size
     """
-    if "pantheon" in [environ.get("DESKTOP_SESSION").lower(),
-                      environ.get("XDG_CURRENT_DESKTOP").lower()]:
+    try:
+        desktop_env = environ.get("DESKTOP_SESSION").lower(),
+        environ.get("XDG_CURRENT_DESKTOP").lower()
+    except AttributeError:
+        desktop_env = []
+        pass
+
+    if "pantheon" in desktop_env:
         return "pantheon"
     else:
         try:


### PR DESCRIPTION
If the user is not running a DE this is throwing an AttributeError because some of those variables might not be set.

I use only bspwm and with this fix I can properly apply the changes without starting a full gnome session. I suppose the same happens to users of i3/awesome/openbox, etc.