### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/database/scripts/data_pack.py
+++ b/database/scripts/data_pack.py
@@ -54,7 +54,7 @@ def ReadDataPack(input_file):
     version, num_entries, encoding = struct.unpack('<IIB',
                                                    data[:HEADER_LENGTH])
     if version != PACK_FILE_VERSION:
-        print('Wrong file version in %s' % input_file)
+        print('Wrong file version in {0!s}'.format(input_file))
         raise Exception
 
     resources = {}


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)