### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/modules/applications/zip.py
+++ b/modules/applications/zip.py
@@ -34,7 +34,7 @@ class ZipApplication(Application):
     def __init__(self, application_data, svgtopng):
         Application.__init__(self, application_data, svgtopng)
         self.binary = self.app.data["binary"]
-        self.tmp_path = "/tmp/_%s/" % self.get_name()
+        self.tmp_path = "/tmp/_{0!s}/".format(self.get_name())
         self.tmp_data = self.tmp_path + self.app.data["zip_path"]
 
     def reinstall(self):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)