### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/modules/svg/cairosvg.py
+++ b/modules/svg/cairosvg.py
@@ -52,7 +52,7 @@ class CairoSVG(SVG):
         width, height = self.get_size(width, height)
         tmp_file = ""
         if len(self.colors) != 0:
-            tmp_file = "/tmp/%s" % path.basename(input_file)
+            tmp_file = "/tmp/{0!s}".format(path.basename(input_file))
             copy_file(input_file, tmp_file)
             input_file = tmp_file
             replace_colors(input_file, self.colors)

--- a/modules/svg/inkscape.py
+++ b/modules/svg/inkscape.py
@@ -43,7 +43,7 @@ class Inkscape(SVG):
         """Convert svg to png."""
         tmp_file = ""
         if len(self.colors) != 0:
-            tmp_file = "/tmp/%s" % path.basename(input_file)
+            tmp_file = "/tmp/{0!s}".format(path.basename(input_file))
             copy_file(input_file, tmp_file)
             input_file = tmp_file
             replace_colors(input_file, self.colors)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)