### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/modules/applications/electron.py
+++ b/modules/applications/electron.py
@@ -49,7 +49,7 @@ class ElectronApplication(Application):
     def install_icon(self, icon, icon_path):
         """Install the icon."""
         filename = icon_path + self.get_binary()
-        icon_to_repl = "files/%s" % "/files/".join(icon["original"].split("/"))
+        icon_to_repl = "files/{0!s}".format("/files/".join(icon["original"].split("/")))
         icon_for_repl = icon["theme"]
         icon_extension = icon["theme_ext"]
         asarfile = open(filename, 'rb')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)