### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/modules/svg/imagemagick.py
+++ b/modules/svg/imagemagick.py
@@ -38,7 +38,7 @@ class ImageMagick(SVG):
         """Convert svg to png."""
         cmd = [self.cmd, "-background", "none"]
         if width and height:
-            cmd.extend(["-size", "%sx%s" % (str(width), str(height))])
+            cmd.extend(["-size", "{0!s}x{1!s}".format(str(width), str(height))])
         cmd.extend([input_file, output_file])
         execute(cmd)
 

--- a/modules/svg/svgexport.py
+++ b/modules/svg/svgexport.py
@@ -38,7 +38,7 @@ class SVGExport(SVG):
         """Convert svg to png."""
         cmd = [self.cmd, input_file, output_file]
         if width and height:
-            cmd.extend(["%s:%s" % (str(width), str(height))])
+            cmd.extend(["{0!s}:{1!s}".format(str(width), str(height))])
         cmd.extend([input_file, output_file])
         execute(cmd)
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)