### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -172,13 +172,13 @@ def get_iterated_icons(icons):
 def get_list_of_themes():
     """Return a list of installed icon themes."""
     paths = ["/usr/share/icons/",
-             "%s/.local/share/icons/" % USERHOME]
+             "{0!s}/.local/share/icons/".format(USERHOME)]
     themes = []
     for icon_path in paths:
         sub_dirs = listdir(icon_path)
         for theme in sub_dirs:
             theme_path = path.join(icon_path, theme) + "/"
-            theme_index = "%sindex.theme" % theme_path
+            theme_index = "{0!s}index.theme".format(theme_path)
             if (path.exists(theme_path) and path.exists(theme_index)
                     and theme not in themes):
                 themes.append(theme)
@@ -191,7 +191,7 @@ def create_icon_theme(theme_name, themes_list):
         theme = Gtk.IconTheme()
         theme.set_custom_theme(theme_name)
     else:
-        exit("The theme %s is not installed on your system." % theme_name)
+        exit("The theme {0!s} is not installed on your system.".format(theme_name))
     return theme
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)