### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -364,7 +364,7 @@ def replace_colors(file_name, colors):
 
 def log(message, error_type=logging.DEBUG):
     func = inspect.currentframe().f_back.f_code
-    error = "%s: %s in %s:%i" % (message, func.co_name, func.co_filename, func.co_firstlineno)
+    error = "{0!s}: {1!s} in {2!s}:{3:d}".format(message, func.co_name, func.co_filename, func.co_firstlineno)
     if error_type == logging.ERROR:
         logging.error(error)
     else:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)