### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -59,9 +59,8 @@ def progress(count, count_max, app_name=""):
     percents = round(100.0 * count / float(count_max), 1)
     progress_bar = '#' * filled_len + '.' * (bar_len - filled_len)
 
-    stdout.write("\r%s%s" % (app_name, " " * (abs(len(app_name) - space))))
-    stdout.write('[%s] %i/%i %s%s\r' %
-                 (progress_bar, count, count_max, percents, '%'))
+    stdout.write("\r{0!s}{1!s}".format(app_name, " " * (abs(len(app_name) - space))))
+    stdout.write('[{0!s}] {1:d}/{2:d} {3!s}{4!s}\r'.format(progress_bar, count, count_max, percents, '%'))
     print("")
     stdout.flush()
 
@@ -134,7 +133,7 @@ def get_scaling_factor(desktop_env):
                         break
             logging.debug("Scaling factor was detected in the KDE configuration with the value %s", scaling_factor)
         except (FileNotFoundError, KeyError) as kde_error:
-            logging.debug("KDE scaling factor not detected, error : %s" % kde_error)
+            logging.debug("KDE scaling factor not detected, error : {0!s}".format(kde_error))
     return scaling_factor
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:bil-elmoussaoui:Hardcode-Tray?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)