### PR TITLE
Add default telegram path (installed from ppa)

### DIFF
--- a/database/telegram.json
+++ b/database/telegram.json
@@ -3,7 +3,8 @@
     "app_path": [
       "{userhome}/.TelegramDesktop/Telegram",
       "{userhome}/.local/share/TelegramDesktop/Telegram",
-      "/usr/bin/telegram-desktop"
+      "/usr/bin/telegram-desktop",
+      "/opt/telegram/Telegram"
     ],
     "icons_path": [
         "{userhome}/.TelegramDesktop/tdata/ticons/",


### PR DESCRIPTION
When Telegram-desktop installed from ppa, this is usual path (ubuntu 14.04+)