### PR TITLE
Add support for keebuntu tray icon

### DIFF
--- a/database/keebuntu.json
+++ b/database/keebuntu.json
@@ -1,0 +1,20 @@
+{
+    "name": "KeePass",
+    "app_path": [
+        "/usr/share/keepass/"
+    ],
+    "icons_path": [
+        "/usr/share/icons/hicolor/256x256/apps/"
+    ],
+    "is_qt": false,
+    "force_create_folder": false,
+    "exec_path_script": false,
+    "is_script": false,
+    "backup_ignore": false,
+    "icons": {
+        "indicator": {
+            "original": "keepass2-locked.png",
+            "theme": "keepassx-indicator"
+        }
+    }
+}

--- a/database/keepass.json
+++ b/database/keepass.json
@@ -14,7 +14,7 @@
     "icons": {
         "indicator": {
             "original": "keepass2-locked.png",
-            "theme": "keepassx-indicator"
+            "theme": "keepassx-locked"
         }
     }
 }


### PR DESCRIPTION
`keeubuntu` is required for changing the tray icon.