### PR TITLE
Fixes dropbox path issue

### DIFF
--- a/src/path.py
+++ b/src/path.py
@@ -30,8 +30,8 @@ def dropbox_callback(directory):
         directory(str): the default dropbox directory
     """
     if path.isdir(directory):
-        sub_dir = directory.split("-")
-        return len(sub_dir) > 1 and sub_dir[0].lower() == "dropbox"
+        sub_dir = directory.split("/")
+        return len(sub_dir) > 1 and sub_dir[4].lower() == "dropbox"
     return False
 
 


### PR DESCRIPTION
In case of my path, dropbox downloads its files at

/home/usrid/.dropbox-dist/dropbox-lnx.x86_64-26.4.24

which makes the current code fail. A better way for this probably is to split by "/" and then check that the fith elem starts with drobox.
Here's a PR that does that.