### PR TITLE
WebTorrent Desktop fix

### DIFF
--- a/data/database/webtorrent-desktop.json
+++ b/data/database/webtorrent-desktop.json
@@ -1,0 +1,16 @@
+{
+    "name": "WebTorrent Desktop",
+    "app_path": [
+        "/opt/webtorrent-desktop/"
+    ],
+    "icons_path": [
+        "/opt/webtorrent-desktop/resources/app.asar.unpacked/static/"
+    ],
+    "icons": {
+        "tray": {
+            "original": "WebTorrent.png",
+            "theme": "webtorrent-desktop-panel"
+        }
+        
+    }
+}

--- a/data/database/webtorrent-desktop.json
+++ b/data/database/webtorrent-desktop.json
@@ -2,16 +2,16 @@
     "name": "WebTorrent Desktop",
     "app_path": [
         "/opt/webtorrent-desktop/",
-	"/usr/share/webtorrent-desktop/"
+	    "/usr/share/webtorrent-desktop/"
     ],
     "icons_path": [
         "/opt/webtorrent-desktop/resources/app.asar.unpacked/static/"
+	    "/usr/share/webtorrent-desktop/resources/app.asar.unpacked/static/"
     ],
     "icons": {
         "tray": {
             "original": "WebTorrent.png",
             "theme": "webtorrent-desktop-panel"
         }
-        
     }
 }

--- a/data/database/webtorrent-desktop.json
+++ b/data/database/webtorrent-desktop.json
@@ -1,7 +1,8 @@
 {
     "name": "WebTorrent Desktop",
     "app_path": [
-        "/opt/webtorrent-desktop/"
+        "/opt/webtorrent-desktop/",
+	"/usr/share/webtorrent-desktop/"
     ],
     "icons_path": [
         "/opt/webtorrent-desktop/resources/app.asar.unpacked/static/"

--- a/data/database/webtorrent-desktop.json
+++ b/data/database/webtorrent-desktop.json
@@ -5,7 +5,7 @@
 	    "/usr/share/webtorrent-desktop/"
     ],
     "icons_path": [
-        "/opt/webtorrent-desktop/resources/app.asar.unpacked/static/"
+        "/opt/webtorrent-desktop/resources/app.asar.unpacked/static/",
 	    "/usr/share/webtorrent-desktop/resources/app.asar.unpacked/static/"
     ],
     "icons": {


### PR DESCRIPTION
It's electron app, but asar unpacked (for icons only). For right work need use with `StartupWMClass=WebTorrent`, because desktop icon show as tray icon without WMClass...