### PR TITLE
Add Solus compatibility for Wire

### DIFF
--- a/data/database/wire.electron.json
+++ b/data/database/wire.electron.json
@@ -2,11 +2,13 @@
     "name": "Wire",
     "app_path": [
         "/opt/wire-desktop/",
-        "/usr/lib/wire-desktop/"
+        "/usr/lib/wire-desktop/",
+        "/usr/share/wire/"
     ],
     "icons_path": [
         "/opt/wire-desktop/resources/",
-        "/usr/lib/wire-desktop/resources/"
+        "/usr/lib/wire-desktop/resources/",
+        "/usr/share/wire/resources/"
     ],
     "binary": "app.asar",
     "script": "electron",


### PR DESCRIPTION
Compatibility fix for Wire installed from the Solus main repo.
[https://solus-project.com/](https://solus-project.com/)