### PR TITLE
Adding `base-devel` to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Here's a list of themes that supports Hardcode-Tray:
 
 ### Arch Linux (AUR)
 
+Make sure the `base-devel` group is installed:
+
+```bash
+sudo pacman -S base-devel
+```
+
 Stable version:
 
 ```bash


### PR DESCRIPTION
On arch, `pkg-config` is needed for `sni-qt-patched`. It is a part of the `base-devel` group.