### PR TITLE
Re-add non-QT hp-printing JSON file

### DIFF
--- a/data/database/hp-printing.json
+++ b/data/database/hp-printing.json
@@ -1,0 +1,16 @@
+{
+    "name": "HP Printer",
+    "app_path": [
+        "/usr/bin/hp-systray"
+    ],
+    "icons_path": [
+        "/usr/share/hplip/data/images/16x16",
+        "/usr/share/hplip/data/images/32x32"
+    ],
+    "icons": {
+        "tray": {
+            "original": "hp_logo.png",
+            "theme": "hp-indicator"
+        }
+    }
+}


### PR DESCRIPTION
I recently switched from the release version to the git version of Hardcode-Tray on Arch Linux, and noticed that the `hp-printing.json` is no longer present.

Would be great if this could be re-added, as it allows fixing of HPLIP hardcoded icons without the need to install any QT-related dependencies.