### PR TITLE
Adapt to currently installed Inkscape version

### DIFF
--- a/HardcodeTray/modules/svg/inkscape.py
+++ b/HardcodeTray/modules/svg/inkscape.py
@@ -21,6 +21,9 @@ along with Hardcode-Tray. If not, see <http://www.gnu.org/licenses/>.
 from HardcodeTray.modules.svg.svg import SVG, SVGNotInstalled
 from HardcodeTray.utils import execute
 
+from semantic_version import Version
+from subprocess import run, PIPE
+
 
 class Inkscape(SVG):
     """Inkscape implemntation of SVG Interface."""
@@ -30,13 +33,22 @@ class Inkscape(SVG):
         super(Inkscape, self).__init__(colors)
 
         self.cmd = "inkscape"
+        self.check_version()
         if not self.is_installed():
             raise SVGNotInstalled
 
+    def check_version(self):
+        out = run([self.cmd, '--version'], stdout=PIPE)
+        version_str = out.split(' ')[1]
+        self.version = Version(version_str)
+
     def convert_to_png(self, input_file, output_file, width=None, height=None):
         """Convert svg to png."""
-        cmd = [self.cmd, "-z", "-f", input_file, "-e", output_file]
-
+        if self.version.major == 0:
+            cmd = [self.cmd, "-z", "-f", input_file, "-e", output_file]
+        else:
+            cmd = [self.cmd, "-z", input_file, "-o",
+                   output_file, "--export-type", "png"]
         if width and height:
             cmd.extend(["-w", str(width), "-h", str(height)])
 

--- a/HardcodeTray/modules/svg/svg.py
+++ b/HardcodeTray/modules/svg/svg.py
@@ -87,8 +87,8 @@ class SVG:
     def to_bin(self, input_file, width=None, height=None):
         """Convert svg to binary."""
         with NamedTemporaryFile(delete=False) as temppng:
-            self.to_png(input_file, temppng.name, width, height)
-            temppng_path = temppng.name
+            temppng_path = f"{temppng.name}.png"
+            self.to_png(input_file, temppng_path, width, height)
         del temppng
 
         # Changes to `temppng` made by the conversion tool may not be picked up


### PR DESCRIPTION
Thanks for this nice tool, I could finally fix the ugly discord icon in my tray bar.

I had some trouble running it at first, and found out that Inkscape was silently failing to convert SVG icons from the theme. This is because my system had Inkscape 1.2.2 whose CLI differs from 0.92, the reference version in the code.

This PR attempts to fix this by parsing `inkscape --version` to find out whether it is `>=1` and adapt system calls accordingly.
It also adds `.png` extension to temporary PNG files, which seems to be required for Inkscape to output anything for some reason. This should be harmless in the general case.

An additional dependency on Python module `semantic-version` was added, but not included yet in `meson.build` (could not figure out how to, if it's even possible) or in the `README`. It could easily be removed if you would rather avoid adding extra dependencies, and just add some code to parse Inkscape's version. 