### PR TITLE
Restore Spotify support

### DIFF
--- a/data/database/spotify.json
+++ b/data/database/spotify.json
@@ -1,0 +1,47 @@
+{
+    "name": "Spotify",
+    "app_path": [
+        "/opt/spotify/"
+    ],
+    "icons_path": [
+        "/opt/spotify/icons"
+    ],
+    "icons": {
+        "spotify_icon16": {
+            "original": "spotify-linux-16.png",
+            "theme": "spotify-indicator"
+        },
+        "spotify_icon22": {
+            "original": "spotify-linux-22.png",
+            "theme": "spotify-indicator"
+        },
+        "spotify_icon24": {
+            "original": "spotify-linux-24.png",
+            "theme": "spotify-indicator"
+        },
+        "spotify_icon32": {
+            "original": "spotify-linux-32.png",
+            "theme": "spotify-indicator"
+        },
+        "spotify_icon48": {
+            "original": "spotify-linux-48.png",
+            "theme": "spotify-indicator"
+        },
+        "spotify_icon64": {
+            "original": "spotify-linux-64.png",
+            "theme": "spotify-indicator"
+        },
+        "spotify_icon128": {
+            "original": "spotify-linux-128.png",
+            "theme": "spotify-indicator"
+        },
+        "spotify_icon256": {
+            "original": "spotify-linux-256.png",
+            "theme": "spotify-indicator"
+        },
+        "spotify_icon512": {
+            "original": "spotify-linux-512.png",
+            "theme": "spotify-indicator"
+        }
+    }
+}

--- a/data/database/spotify.json
+++ b/data/database/spotify.json
@@ -1,10 +1,14 @@
 {
     "name": "Spotify",
     "app_path": [
-        "/opt/spotify/"
+        "/opt/spotify/",
+        "/var/lib/flatpak/app/com.spotify.Client/",
+        "{userhome}/.var/app/com.spotify.Client/"
     ],
     "icons_path": [
-        "/opt/spotify/icons"
+        "/opt/spotify/icons",
+        "/var/lib/flatpak/app/com.spotify.Client/current/active/files/extra/share/spotify/icons",
+        "{userhome}/.local/share/flatpak/app/com.spotify.Client/current/active/files/extra/share/spotify/icons"
     ],
     "icons": {
         "spotify_icon16": {

--- a/data/database/spotify.json
+++ b/data/database/spotify.json
@@ -11,40 +11,8 @@
         "{userhome}/.local/share/flatpak/app/com.spotify.Client/current/active/files/extra/share/spotify/icons"
     ],
     "icons": {
-        "spotify_icon16": {
-            "original": "spotify-linux-16.png",
-            "theme": "spotify-indicator"
-        },
-        "spotify_icon22": {
-            "original": "spotify-linux-22.png",
-            "theme": "spotify-indicator"
-        },
-        "spotify_icon24": {
-            "original": "spotify-linux-24.png",
-            "theme": "spotify-indicator"
-        },
         "spotify_icon32": {
             "original": "spotify-linux-32.png",
-            "theme": "spotify-indicator"
-        },
-        "spotify_icon48": {
-            "original": "spotify-linux-48.png",
-            "theme": "spotify-indicator"
-        },
-        "spotify_icon64": {
-            "original": "spotify-linux-64.png",
-            "theme": "spotify-indicator"
-        },
-        "spotify_icon128": {
-            "original": "spotify-linux-128.png",
-            "theme": "spotify-indicator"
-        },
-        "spotify_icon256": {
-            "original": "spotify-linux-256.png",
-            "theme": "spotify-indicator"
-        },
-        "spotify_icon512": {
-            "original": "spotify-linux-512.png",
             "theme": "spotify-indicator"
         }
     }


### PR DESCRIPTION
The system tray indicator is available again.

Flatpak support is not included because the package has not been updated for some time. I could add it by guessing the paths, just an idea.