### PR TITLE
Support for Skype in /opt

### DIFF
--- a/data/database/skype.json
+++ b/data/database/skype.json
@@ -2,10 +2,12 @@
     "name": "Skype",
     "app_path": [
         "/usr/share/skypeforlinux/",
+        "/opt/skypeforlinux/",
         "/var/lib/flatpak/app/com.skype.Client/"
     ],
     "icons_path": [
         "/usr/share/skypeforlinux/resources/app.asar.unpacked/images/tray",
+        "/opt/skypeforlinux/resources/app.asar.unpacked/images/tray",
         "/var/lib/flatpak/app/com.skype.Client/current/active/files/extra/share/skypeforlinux/resources/app.asar.unpacked/images/tray"
     ],
     "icons": {


### PR DESCRIPTION
Hi, this is (should be) a simple change to support a Skype installation in `/opt`. One such use-case is AUR's [skypeforlinux-bin](https://aur.archlinux.org/packages/skypeforlinux-bin).